### PR TITLE
Fix enumerable bug

### DIFF
--- a/contracts/Llama.vy
+++ b/contracts/Llama.vy
@@ -651,6 +651,12 @@ def tokenOfOwnerByIndex(owner: address, index: uint256) -> uint256:
     return self.ids_by_owner[owner][index]
 
 
+@external
+@view
+def tokensForOwner(owner: address) -> DynArray[uint256, max_supply]:
+    return self.ids_by_owner[owner]
+
+
 ## Signature helper
 
 @internal

--- a/tests/nft/test_enumerable.py
+++ b/tests/nft/test_enumerable.py
@@ -36,3 +36,13 @@ def test_tokenOfOwnerByIndex_accurate(minted, deployer, minted_token_id, bob):
     assert minted.tokenOfOwnerByIndex(deployer, 1) == minted_token_id + 4
     with brownie.reverts():
         assert minted.tokenOfOwnerByIndex(deployer, 2)
+
+
+def test_tokensForOwner(minted, deployer, minted_token_id, bob):
+    assert minted.tokensForOwner(deployer) == [minted_token_id]
+    minted.mint()
+    assert minted.tokensForOwner(deployer) == [minted_token_id, minted_token_id + 1]
+
+    minted.transferFrom(deployer, bob, minted_token_id, {"from": deployer})
+    assert minted.tokensForOwner(deployer) == [minted_token_id + 1]
+    assert minted.tokensForOwner(bob) == [minted_token_id]


### PR DESCRIPTION
Closes #5.

Incorporated a "swap and pop" logic to track NFTs for each user.  Should be O(1) when adding or removing a token.

Testing is a bit messy.  I will clean it up and test more rigorously.  But the basic implementation is there, check it out!  Also we can probably get rid of the `balances` counter since it is just the length of the ids array.