### PR TITLE
Use newer ganache version in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.12.2
+      run: npm install -g ganache@7.0.2
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,2 +1,7 @@
 dev_deployment_artifacts: true
 dotenv: .env
+
+networks:
+  development:
+      cmd_settings:
+          evm_version: berlin

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,7 @@ include_trailing_comma = True
 line_length = 100
 multi_line_output = 3
 use_parentheses = True
+
+[tool:pytest]
+filterwarnings =
+    ignore::DeprecationWarning:eth_abi.*:


### PR DESCRIPTION
Also, specify berlin hardfork in brownie config.  Silence deprecation warning from a package in pytest runs.

Closes #8.