### PR TITLE
Add identity precompile to the auction house

### DIFF
--- a/contracts/LlamaAuctionHouse.vy
+++ b/contracts/LlamaAuctionHouse.vy
@@ -65,6 +65,9 @@ event AuctionSettled:
     _amount: uint256
 
 
+# Technically vyper doesn't need this as it is automatic
+# in all recent vyper versions, but Etherscan verification
+# will bork without it.
 IDENTITY_PRECOMPILE: constant(
     address
 ) = 0x0000000000000000000000000000000000000004


### PR DESCRIPTION
The identity precompile is an optimization to allow fast copy from one area of memory to another.  For some reason, Etherscan verification seems to assume this optimization somewhere when it compiles the contract so NOT including this means verification will bork!

This fix was checked against the online compiler, which seems to work fine with the NFT contract.  Still need to check with an actual deployment.