### PR TITLE
Set brownie config to compile using berlin

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -5,3 +5,6 @@ networks:
   development:
       cmd_settings:
           evm_version: berlin
+
+compiler:
+  evm_version: berlin


### PR DESCRIPTION
Testing evidence: https://goerli.etherscan.io/address/0xCF20473fEaC645cF211CD34BB929b45F2Ff468Ae#code

Not much to add.  Turns out the Etherscan verification issues are caused by Brownie using instanbul compiler settings.