### PR TITLE
Optimize signature verification

### DIFF
--- a/contracts/LlamaAuctionHouse.vy
+++ b/contracts/LlamaAuctionHouse.vy
@@ -168,7 +168,9 @@ def create_friend_bid(llama_id: uint256, bid_amount: uint256, sig: Bytes[65]):
     """
 
     assert self.wl_enabled == True, "WL auction is not enabled"
-    assert self._check_signature(sig, "friend:", msg.sender), "Signature is invalid"
+    assert self._check_signature(
+        sig, "friend:", msg.sender
+    ), "Signature is invalid"
     assert self.wl_auctions_won[msg.sender] < 1, "Already won 1 WL auction"
 
     self._create_bid(llama_id, bid_amount)
@@ -186,7 +188,9 @@ def create_wl_bid(llama_id: uint256, bid_amount: uint256, sig: Bytes[65]):
     """
 
     assert self.wl_enabled == True, "WL auction is not enabled"
-    assert self._check_signature(sig, "whitelist:", msg.sender), "Signature is invalid"
+    assert self._check_signature(
+        sig, "whitelist:", msg.sender
+    ), "Signature is invalid"
     assert self.wl_auctions_won[msg.sender] < 2, "Already won 2 WL auctions"
 
     self._create_bid(llama_id, bid_amount)
@@ -466,7 +470,9 @@ def _unpause():
 
 @internal
 @view
-def _check_signature(sig: Bytes[65], keyword: String[10], sender: address) -> bool:
+def _check_signature(
+    sig: Bytes[65], keyword: String[10], sender: address
+) -> bool:
     ethSignedHash: bytes32 = keccak256(
         concat(
             b"\x19Ethereum Signed Message:\n32",
@@ -478,5 +484,5 @@ def _check_signature(sig: Bytes[65], keyword: String[10], sender: address) -> bo
         ethSignedHash,
         convert(slice(sig, 64, 1), uint256),
         convert(slice(sig, 0, 32), uint256),
-        convert(slice(sig, 32, 32), uint256)
+        convert(slice(sig, 32, 32), uint256),
     )


### PR DESCRIPTION
These changes may be too late for the WL auction today, but valuable for future applications.

# Changes
- Add `_check_signature`, the consolidated form of `_check_wl_signature` and `_check_friend_signature`
- Replace single-use variables with literal values (see brownie gas report below for differences in gas)

Before
```
create_wl_bid                         -  avg:   77793  avg (confirmed):   97175  low:   38782  high:  113262
create_friend_bid                     -  avg:   73259  avg (confirmed):  113233  low:   38753  high:  113233
```

After
```
create_wl_bid                         -  avg:   77784  avg (confirmed):   97163  low:   38769  high:  113252
create_friend_bid                     -  avg:   73248  avg (confirmed):  113217  low:   38740  high:  113223
```