### PR TITLE
Change send to raw_call to avoid out of gas error

### DIFF
--- a/contracts/LlamaAuctionHouse.vy
+++ b/contracts/LlamaAuctionHouse.vy
@@ -218,7 +218,7 @@ def withdraw():
 
     pending_amount: uint256 = self.pending_returns[msg.sender]
     self.pending_returns[msg.sender] = 0
-    send(msg.sender, pending_amount)
+    raw_call(msg.sender, b"", value=pending_amount)
 
     log Withdraw(msg.sender, pending_amount)
 
@@ -243,10 +243,10 @@ def withdraw_stale(addresses: DynArray[address, ADMIN_MAX_WITHDRAWALS]):
         fee: uint256 = (pending_amount * 5) / 100
         withdrawer_return: uint256 = pending_amount - fee
         self.pending_returns[_address] = 0
-        send(_address, withdrawer_return)
+        raw_call(_address, b"", value=withdrawer_return)
         total_fee += fee
 
-    send(self.owner, total_fee)
+    raw_call(self.owner, b"", value=total_fee)
 
 
 @external
@@ -411,7 +411,7 @@ def _settle_auction():
         if self.wl_enabled:
             self.wl_auctions_won[self.auction.bidder] += 1
     if self.auction.amount > 0:
-        send(self.owner, self.auction.amount)
+        raw_call(self.owner, b"", value=self.auction.amount)
 
     log AuctionSettled(
         self.auction.llama_id, self.auction.bidder, self.auction.amount

--- a/contracts/test/BasicSafe.vy
+++ b/contracts/test/BasicSafe.vy
@@ -1,0 +1,13 @@
+# @version 0.3.7
+
+owner: public(address)
+
+@external
+def __init__():
+    pass
+
+@external
+@payable
+def __default__():
+    # Do something that wastes gas.
+    self.owner = msg.sender

--- a/tests/auction/test_auction_house.py
+++ b/tests/auction/test_auction_house.py
@@ -728,6 +728,18 @@ def test_settle_auction_with_bid(token, deployer, auction_house_unpaused, alice)
     assert deployer_balance_after == deployer_balance_before + 100
 
 
+def test_settle_current_and_create_new_auction_with_bid_smart_contract_owner(token, smart_contract_owner, auction_house_sc_owner, alice):
+    assert not auction_house_sc_owner.auction()["settled"]
+    auction_house_sc_owner.create_bid(20, 100, {"from": alice, "value": "100 wei"})
+    chain.sleep(1000)
+    deployer_balance_before = smart_contract_owner.balance()
+    auction_house_sc_owner.settle_current_and_create_new_auction()
+    deployer_balance_after = smart_contract_owner.balance()
+    assert auction_house_sc_owner.auction()["llama_id"] == 21
+    assert token.ownerOf(20) == alice
+    assert deployer_balance_after == deployer_balance_before + 100 
+
+
 def test_settle_current_and_create_new_auction_with_bid(deployer, auction_house_unpaused, alice):
     auction_house_unpaused.disable_wl()
     assert not auction_house_unpaused.auction()["settled"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,11 @@ def deployer():
 
 
 @pytest.fixture(scope="function")
+def smart_contract_owner(BasicSafe, accounts):
+    return BasicSafe.deploy({"from": accounts[0]})
+
+
+@pytest.fixture(scope="function")
 def alice():
     return accounts[1]
 
@@ -111,4 +116,13 @@ def auction_house_unpaused(LlamaAuctionHouse, token, deployer):
     auction_house = LlamaAuctionHouse.deploy(token, 100, 100, 5, 100, {"from": deployer})
     token.set_minter(auction_house)
     auction_house.unpause()
+    return auction_house
+
+@pytest.fixture(scope="function")
+def auction_house_sc_owner(LlamaAuctionHouse, token, deployer, smart_contract_owner):
+    auction_house = LlamaAuctionHouse.deploy(token, 100, 100, 5, 100, {"from": deployer})
+    token.set_minter(auction_house)
+    auction_house.unpause()
+    auction_house.disable_wl()
+    auction_house.set_owner(smart_contract_owner, {"from": deployer})
     return auction_house


### PR DESCRIPTION
send only forwards 2300 gas so if sending to a smart contract it will revert if the contract does anything except for just receiving the eth.

Replacing this with `raw_call` forwards all the gas and does not error